### PR TITLE
Task 3. K8s Cluster Creation and Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 This repository contains Terraform infrastructure tasks for a DevOps course.
 
+## Usage
+
+Run `make` to deploy the infrastructure. The Makefile includes the following targets:
+
+- `format`: Formats Terraform files
+- `check`: Checks formatting of Terraform files
+- `validate`: Validates Terraform files
+- `init`: Initializes Terraform
+- `plan`: Creates an execution plan
+- `apply`: Applies the Terraform configuration
+- `destroy`: Destroys the infrastructure
+
+## CI/CD
+
+GitHub Actions runs on push, PR, and manual triggers:
+
+- Checks formatting
+- Plans infrastructure
+- Applies to AWS (on main)
+
+## Notes
+
+- State is stored in an S3 bucket
+- CI assumes an IAM role via OIDC
+
 ## Architecture
 
 The architecture consists of a VPC with two availability zones (AZ1 and AZ2), each containing public and private subnets. The bastion host is in the public subnet of AZ2, while the public VM is in the public subnet of AZ1. The private VMs are in their respective private subnets.
@@ -54,74 +79,185 @@ The following table lists the VMs created in the infrastructure.
 | private-vm-a     | i-01316392d209f28fb    | eu-west-1a | —                | 10.0.101.26    | private-vm-sg   |
 | private-vm-b     | i-06deb0195ce41bde2    | eu-west-1b | —                | 10.0.102.55    | private-vm-sg   |
 
-## Tests
+## Connectivity Testing
 
 Each VM has been tested for connectivity as follows.
 
 1. Bastion VM
 
-```
-ssh -A ec2-user@34.248.59.113
-[ec2-user@ip-10-0-1-155 ~]$ curl -s ifconfig.me      # Via IGW
-34.248.59.113
-[ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.2.48   # Connects to public VM
-[ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.101.26 # Connects to private VM A
-[ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.102.55 # Connects to private VM B
-```
+   ```
+   ssh -A ec2-user@34.248.59.113
+   [ec2-user@ip-10-0-1-155 ~]$ curl -s ifconfig.me      # Via IGW
+   34.248.59.113
+   [ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.2.48   # Connects to public VM
+   [ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.101.26 # Connects to private VM A
+   [ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.102.55 # Connects to private VM B
+   ```
 
 2. Public VM
 
-```
-ssh -A ec2-user@3.254.135.50
-[ec2-user@ip-10-0-2-82 ~]$ curl -s ifconfig.me       # Via IGW
-3.254.135.50
-[ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.101.26 # Does not connect to private VM A
-[ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.102.55 # Does not connect to private VM B
-```
+   ```
+   ssh -A ec2-user@3.254.135.50
+   [ec2-user@ip-10-0-2-82 ~]$ curl -s ifconfig.me       # Via IGW
+   3.254.135.50
+   [ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.101.26 # Does not connect to private    VM A
+   [ec2-user@ip-10-0-1-155 ~]$ ssh ec2-user@10.0.102.55 # Does not connect to private    VM B
+   ```
 
 3. Private VM A
 
-```
-ssh -A ec2-user@34.248.59.113                           # Connects to bastion
-[ec2-user@ip-10-0-1-155 ~]$ ssh -A ec2-user@10.0.101.26 # Connects to private VM A
-[ec2-user@ip-10-0-101-26 ~]$ curl ifconfig.me           # Via NAT
-63.35.144.83
-[ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.2.48     # Connects to public VM
-[ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.102.55   # Does not connect to private VM B
-```
+   ```
+   ssh -A ec2-user@34.248.59.113                           # Connects to bastion
+   [ec2-user@ip-10-0-1-155 ~]$ ssh -A ec2-user@10.0.101.26 # Connects to private VM A
+   [ec2-user@ip-10-0-101-26 ~]$ curl ifconfig.me           # Via NAT
+   63.35.144.83
+   [ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.2.48     # Connects to public VM
+   [ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.102.55   # Does not connect to    private VM B
+   ```
 
 4. Private VM B
 
+   ```
+   ssh -A ec2-user@34.248.59.113                           # Connects to bastion
+   [ec2-user@ip-10-0-1-155 ~]$ ssh -A ec2-user@10.0.102.55 # Connects to private VM B
+   [ec2-user@ip-10-0-101-26 ~]$ curl ifconfig.me           # Via NAT
+   63.35.144.83
+   [ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.2.48     # Connects to public VM
+   [ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.101.26   # Does not connect to    private VM A
+   ```
+
+## K3s Cluster Setup
+
+Install and configure a lightweight Kubernetes (k3s) cluster on AWS EC2 instances provisioned by Terraform.
+
+The following table lists the private and public IP addresses of the EC2 instances:
+
+| Name         | Private IP     | Public IP        |
+|--------------|----------------|------------------|
+| public-vm    | 10.0.2.175     | 3.250.121.94     |
+| bastion-host | 10.0.1.117     | 3.253.17.168     |
+| private-vm-a | 10.0.101.123   | None             |
+| private-vm-b | 10.0.102.39    | None             |
+
+### Master Node Setup (private-vm-a)
+
+#### 1. SSH from Bastion
+
+```sh
+ssh -A ubuntu@3.253.17.168
+ssh ubuntu@10.0.101.123
 ```
-ssh -A ec2-user@34.248.59.113                           # Connects to bastion
-[ec2-user@ip-10-0-1-155 ~]$ ssh -A ec2-user@10.0.102.55 # Connects to private VM B
-[ec2-user@ip-10-0-101-26 ~]$ curl ifconfig.me           # Via NAT
-63.35.144.83
-[ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.2.48     # Connects to public VM
-[ec2-user@ip-10-0-101-26 ~]$ ssh ec2-user@10.0.101.26   # Does not connect to private VM A
+
+#### 2. Install k3s Server
+
+```sh
+curl -sfL https://get.k3s.io | sh -
 ```
 
-## Usage
+#### 3. Get Cluster Token
 
-Run `make` to deploy the infrastructure. The Makefile includes the following targets:
+```sh
+sudo cat /var/lib/rancher/k3s/server/node-token
+```
 
-- `format`: Formats Terraform files
-- `check`: Checks formatting of Terraform files
-- `validate`: Validates Terraform files
-- `init`: Initializes Terraform
-- `plan`: Creates an execution plan
-- `apply`: Applies the Terraform configuration
-- `destroy`: Destroys the infrastructure
+#### 4. Verify Node
 
-## CI/CD
+```sh
+sudo k3s kubectl get nodes
+```
 
-GitHub Actions runs on push, PR, and manual triggers:
+You should see output similar to:
 
-- Checks formatting
-- Plans infrastructure
-- Applies to AWS (on main)
+```
+ubuntu@ip-10-0-101-123:~$ sudo k3s kubectl get nodes
+NAME              STATUS   ROLES                  AGE   VERSION
+ip-10-0-101-123   Ready    control-plane,master   1m    v1.32.5+k3s1
+```
 
-## Notes
+### Worker Node Setup (private-vm-b)
 
-- State is stored in an S3 bucket
-- CI assumes an IAM role via OIDC
+#### 1. SSH from Bastion
+
+```sh
+ssh ubuntu@10.0.102.39
+```
+
+#### 2. Install k3s Agent
+
+```sh
+curl -sfL https://get.k3s.io | K3S_URL=https://10.0.101.123:6443 K3S_TOKEN=<token> sh -
+```
+
+Replace `<token>` with the value from the master node.
+
+### Bastion Host Setup
+
+##### 1. SSH into the Bastion Host
+
+```sh
+ssh -A ubuntu@3.253.17.168
+```
+
+#### 2. Install `kubectl`
+
+```sh
+curl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+```
+
+#### 3. Copy the Kubeconfig to the Bastion Host
+
+The file is located at `/etc/rancher/k3s/k3s.yaml` on the master node.
+
+#### 4. Update the Kubeconfig
+
+```sh
+sed -i 's/127.0.0.1/10.0.101.123/' ~/k3s.yaml
+```
+
+#### 5. Verify `kubectl` Configuration
+
+```sh
+export KUBECONFIG=~/k3s.yaml
+kubectl get nodes
+```
+
+You should see output similar to:
+
+```
+NAME              STATUS   ROLES                  AGE   VERSION
+ip-10-0-101-123   Ready    control-plane,master   2m    v1.32.5+k3s1
+ip-10-0-102-39    Ready    worker                 1m    v1.32.5+k3s1
+```
+
+### Access from Local Machine
+
+To access the k3s cluster from your local machine, you need to set up an SSH tunnel.
+
+#### 1. Start SSH Tunnel
+
+```sh
+ssh -i bastion_ssh_key.pem -L 6443:10.0.101.123:6443 ubuntu@3.253.17.168
+```
+
+#### 2. Copy Kubeconfig
+
+```sh
+scp -i bastion_ssh_key.pem ubuntu@3.253.17.168:/home/ubuntu/k3s.yaml ~/.kube/config
+```
+
+#### 3. Update and Use Kubeconfig
+
+Edit `~/.kube/config`:
+
+```yaml
+server: https://localhost:6443
+```
+
+Then run:
+
+```sh
+kubectl get nodes
+kubectl get pods
+```

--- a/infra/instances.tf
+++ b/infra/instances.tf
@@ -8,6 +8,7 @@ resource "aws_instance" "bastion" {
 
   tags = {
     Name = "bastion-host"
+    Role = "bastion"
   }
 }
 
@@ -21,31 +22,40 @@ resource "aws_instance" "public_vm" {
 
   tags = {
     Name = "public-vm"
+    Role = "public"
   }
 }
 
-resource "aws_instance" "private_vm" {
-  ami                         = var.ami_id
-  instance_type               = "t2.micro"
-  subnet_id                   = aws_subnet.private[0].id
-  vpc_security_group_ids      = [aws_security_group.private_vm_sg.id]
+resource "aws_instance" "private_vm_a" {
+  ami           = var.ami_id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.private[0].id
+  vpc_security_group_ids = [
+    aws_security_group.private_vm_sg.id,
+    aws_security_group.k3s_internal.id
+  ]
   associate_public_ip_address = false
   key_name                    = var.key_name
 
   tags = {
     Name = "private-vm-a"
+    Role = "k3s-server"
   }
 }
 
 resource "aws_instance" "private_vm_b" {
-  ami                         = var.ami_id
-  instance_type               = "t2.micro"
-  subnet_id                   = aws_subnet.private[1].id
+  ami           = var.ami_id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.private[1].id
+  vpc_security_group_ids = [
+    aws_security_group.private_vm_sg.id,
+    aws_security_group.k3s_internal.id
+  ]
   associate_public_ip_address = false
-  vpc_security_group_ids      = [aws_security_group.private_vm_sg.id]
   key_name                    = var.key_name
 
   tags = {
     Name = "private-vm-b"
+    Role = "k3s-agent"
   }
 }

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -50,13 +50,54 @@ resource "aws_security_group" "public_vm_sg" {
 
 resource "aws_security_group" "private_vm_sg" {
   name        = "private-vm-sg"
-  description = "Allow SSH from bastion only"
+  description = "Allow SSH from bastion and ICMP from private nodes"
   vpc_id      = aws_vpc.main.id
 
   ingress {
     description     = "SSH from bastion"
     from_port       = 22
     to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.bastion_sg.id]
+  }
+
+  ingress {
+    description = "Allow ICMP (ping) from same SG"
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    self        = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "private-vm-sg"
+  }
+}
+
+resource "aws_security_group" "k3s_internal" {
+  name        = "k3s-internal"
+  description = "Allow k3s API traffic between nodes"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "k3s API within cluster"
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "tcp"
+    self        = true
+  }
+
+  ingress {
+    description     = "k3s API from bastion"
+    from_port       = 6443
+    to_port         = 6443
     protocol        = "tcp"
     security_groups = [aws_security_group.bastion_sg.id]
   }
@@ -69,6 +110,6 @@ resource "aws_security_group" "private_vm_sg" {
   }
 
   tags = {
-    Name = "private-vm-sg"
+    Name = "k3s-internal"
   }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -3,5 +3,5 @@ variable "vpc_cidr" { default = "10.0.0.0/16" }
 variable "public_subnet_cidrs" { default = ["10.0.1.0/24", "10.0.2.0/24"] }
 variable "private_subnet_cidrs" { default = ["10.0.101.0/24", "10.0.102.0/24"] }
 variable "availability_zones" { default = ["eu-west-1a", "eu-west-1b"] }
-variable "ami_id" { default = "ami-01abff0fb51badaf8" } # Red Hat Enterprise Linux version 10
+variable "ami_id" { default = "ami-01f23391a59163da9" } # Ubuntu Server 24.04 LTS
 variable "key_name" { default = "bastion_ssh_key" }


### PR DESCRIPTION
This PR sets up a functional private Kubernetes cluster accessible via a bastion host.

## Networking

- Extended private_vm_sg to allow ICMP within the group for easier troubleshooting.
-  Introduced `k3s_internal` security group:
    - Allows k3s API traffic (TCP 6443) between nodes.
    - Allows k3s API access from the bastion.

The following table lists the private and public IP addresses of the EC2 instances for reference, as well as their roles in the k3s cluster setup:

| Name         | Role        | Private IP     | Public IP        |
|--------------|-------------|----------------|------------------|
| public-vm    | public      | 10.0.2.175     | 3.250.121.94     |
| bastion-host | bastion     | 10.0.1.117     | 3.253.17.168     |
| private-vm-a | k3s-server  | 10.0.101.123   | —                |
| private-vm-b | k3s-agent   | 10.0.102.39    | —                |

## AMI

- Switched base AMI from RHEL to Ubuntu 24.04 LTS for better k3s compatibility.

## Access from a Local Machine

To access the k3s cluster from a local machine, you need to set up an SSH tunnel.

1. Start the SSH tunnel

```sh
ssh -L 6443:10.0.101.123:6443 ubuntu@3.253.17.168
```

2. Copy the Kube config

```sh
scp ubuntu@3.253.17.168:/home/ubuntu/k3s.yaml ~/.kube/config
```

3. Update the Kube config

Edit `~/.kube/config`:

```yaml
server: https://localhost:6443
```

Then run:

```sh
kubectl get nodes
kubectl get pods
```

## Tests

### kubectl get all --all-namespaces

![kubectl_get_all](https://github.com/user-attachments/assets/24459449-9de7-4566-80df-a20289fe169b)

### kubectl get nodes

![kubectl_get_nodes](https://github.com/user-attachments/assets/660d66d4-6e68-402d-97c3-eb5b83fcb92e)

### kubectl get pods

![kubectl_get_pods](https://github.com/user-attachments/assets/65c45920-cf87-4a8e-8a87-5bf330c183fb)

### kubectl get nodes (from a Local Machine)

![kubectl_get_nodes_local png](https://github.com/user-attachments/assets/3d76bcb4-4857-4308-9349-8a7aebd9d3e0)